### PR TITLE
Improve home path resolution method

### DIFF
--- a/agent-scripts/logitech-monitor.scpt
+++ b/agent-scripts/logitech-monitor.scpt
@@ -5,7 +5,7 @@
 --  There shouldn't be a need to change the vendorID, appName, or appPath variables.
 
 -- Path to your LaunchAgent.
-set agentPlist to POSIX path of (path to home folder) & "Library/LaunchAgents/local.StrangeRanger.LogitechMonitor.plist"
+set agentPlist to (do shell script "printf %s \"$HOME\"") & "/Library/LaunchAgents/local.StrangeRanger.LogitechMonitor.plist"
 -- The USB vendor ID and app info.
 set vendorID to "0x046d"
 set appName to "lghub"
@@ -26,4 +26,3 @@ on error errMsg number errNum
     do shell script "launchctl unload " & quoted form of agentPlist
 	return
 end try
-

--- a/agent-scripts/mouse-monitor.scpt
+++ b/agent-scripts/mouse-monitor.scpt
@@ -1,5 +1,5 @@
 -- Description:
--- 	Check if any connected HID mouse is connected, then launch LinearMouse, if not already
+--  Check if any connected HID mouse is connected, then launch LinearMouse, if not already
 --  running, when a mouse is detected.
 -- Note:
 --  This checks the HID usage values for a mouse instead of matching a specific vendor or


### PR DESCRIPTION
This pull request makes a small change to the `agent-scripts/logitech-monitor.scpt` script, improving how the user's home directory is retrieved when constructing the `agentPlist` path.

- Improved reliability of home directory retrieval:
  * Changed the assignment of `agentPlist` to use a shell command (`do shell script "printf %s \"$HOME\""`) for getting the home path, making it more robust and less dependent on AppleScript's path handling.