### PR TITLE
Fix detection of external HID mice with hidutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Updated `mouse-monitor.scpt` to detect any connected HID mouse instead of matching a single configured USB product ID, allowing LinearMouse to launch for mice from any manufacturer.
+- Updated `mouse-monitor.scpt` to detect any connected external HID mouse with `hidutil list` instead of matching a single configured USB product ID, allowing LinearMouse to launch for mice from any manufacturer, including receivers connected through USB hubs or dongles.
 
 ### Fixed
 

--- a/agent-scripts/mouse-monitor.scpt
+++ b/agent-scripts/mouse-monitor.scpt
@@ -4,11 +4,12 @@
 -- Note:
 --  This checks the HID usage values for a mouse instead of matching a specific vendor or
 --  product ID, so it works across mouse manufacturers.
+--  Built-in pointing devices are ignored so this only reacts to a connected external mouse.
 
 -- Path to your LaunchAgent.
 set agentPlist to (do shell script "printf %s \"$HOME\"") & "/Library/LaunchAgents/local.StrangeRanger.MouseMonitor.plist"
 -- The shell command and app info.
-set mouseDetectionCommand to "ioreg -r -c IOHIDDevice -l | awk '/DeviceUsagePage/ && / = 1/ { page=1 } /DeviceUsage/ && !/DeviceUsagePage/ && / = 2/ { usage=1 } /^[ |]*\\+-o / { if (page && usage) found=1; page=0; usage=0 } END { if (page && usage) found=1; print found ? \"1\" : \"0\" }'"
+set mouseDetectionCommand to "hidutil list | awk 'NR > 2 && $4 == 1 && $5 == 2 && $NF == 0 { found=1 } END { print found ? \"1\" : \"0\" }'"
 set appName to "LinearMouse"
 set appPath to "/Applications/LinearMouse.app"
 


### PR DESCRIPTION
This pull request updates the mouse detection logic in `mouse-monitor.scpt` to more reliably detect external HID mice, ensuring that LinearMouse launches for any external mouse, regardless of manufacturer or connection method. The key changes are:

**Improvements to Mouse Detection:**

* Updated `mouse-monitor.scpt` to use the `hidutil list` command instead of `ioreg`, allowing detection of any connected external HID mouse rather than matching a specific USB product ID. This makes the script compatible with mice from any manufacturer, including those connected via USB hubs or dongles. Built-in pointing devices are now ignored, so only external mice trigger the launch. [[1]](diffhunk://#diff-32ad50fbc5076edbb692596a9464dacc9a22120759498cd8384d58af9d5fe8f5R7-R12) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL13-R13)